### PR TITLE
build: Adiciona Makefile para compilação do projeto

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+# Créditos: Adptado do gemini
+
+# Nome do compilador C que será usado
+CC=gcc
+
+# Flags de compilação para exibir todos os avisos (warnings) e erros, o que é uma ótima prática
+CFLAGS=-Wall -Wextra -std=c99
+
+# Nome do arquivo executável que será gerado
+EXECUTAVEL=sig-recipes
+
+# Lista de todos os arquivos-fonte (.c) do seu projeto
+FILES=main.c telas.c utils.c receita.c usuario.c ingrediente.c
+
+# Regra principal: é executada quando você digita apenas "make"
+# Ela diz que para criar o executável, o Makefile depende de todos os arquivos-fonte
+all: $(FILES)
+	$(CC) $(CFLAGS) $(FILES) -o $(EXECUTAVEL)
+
+# "clean": é usada para limpar os arquivos gerados pela compilação
+clean:
+	rm -f $(EXECUTAVEL) *.o
+
+# "run": um atalho para compilar e executar o programa de uma vez
+run: all
+	./$(EXECUTAVEL)

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ git clone https://github.com/pauloandrehxh/SIG-Recipes.git
 cd SIG-Recipes
 
 # 3. Compile o projeto
-gcc -g -Wall -o sig-recipes *.c
+make
 
 # 4. Execute o programa
 # No Linux/macOS:


### PR DESCRIPTION
## Descrição

Este PR introduz um `Makefile` para automatizar e padronizar o processo de compilação do projeto SIG-Recipes. Isso elimina a necessidade de digitar manualmente o longo comando `gcc` a cada alteração no código.

## Alterações

-   Adicionado o arquivo `Makefile` na raiz do projeto.
-   O Makefile inclui as seguintes regras:
    -   `make all` (ou apenas `make`): Compila todos os arquivos-fonte e gera o executável `sig-recipes`.
    -   `make clean`: Remove o executável e outros arquivos de compilação.
    -   `make run`: Compila e executa o programa.
- Atualiza o readme com o tutorial para compilar o projeto usando o `Makefile`.